### PR TITLE
Add API Endpoint for Paginated Retrieval of User's Estates in JSON Format

### DIFF
--- a/app/Http/Controllers/EstatesController.php
+++ b/app/Http/Controllers/EstatesController.php
@@ -72,40 +72,18 @@ class EstatesController extends Controller
         try {
             // Validate the request parameters
             $request->validate([
-                'page' => 'required|integer|min:1',
-                'size' => 'required|integer|min:1',
                 'user' => 'required|integer',
             ]);
 
             // Extract parameters from the request
-            $page = $request->input('page');
-            $size = $request->input('size');
             $userId = $request->input('user');
 
             // Retrieve estates from the database based on user ID in a paginated way
             $estates = Estate::where('user_id', $userId)
-                ->paginate($size, ['*'], 'page', $page);
-
-            // Transform the estates data into the desired JSON format
-            $transformedEstates = $estates->map(function ($estate) {
-                return [
-                    'id' => $estate->id,
-                    'name' => $estate->name,
-                    'lat' => $estate->lat,
-                    'lng' => $estate->lng,
-                    'category' => $estate->category,
-                    'price' => $estate->price,
-                    'currency' => $estate->currency,
-                ];
-            });
+                ->get(['id','name','price','currency','latitude','longitude','category_id']);
 
             // Return the paginated estates in the desired JSON format
-            return response()->json([
-                'estates' => $transformedEstates,
-                'currentPage' => $estates->currentPage(),
-                'lastPage' => $estates->lastPage(),
-                'totalResults' => $estates->total(),
-            ]);
+            return response()->json($estates);
 
         } catch (\Exception $exception) {
             // Handle exceptions and return an error response

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,3 +53,7 @@ Route::controller(EstatesController::class)->prefix('real-estates')->group(funct
 
 /* TODO: Delete test route? */
 Route::get('/real-estates/{id}/reservations', [EstatesController::class, 'getEstateReservations']);
+
+// TODO add estates api path inside the middleware sanctum
+/** --------- ESTATES API --------- */
+Route::get('estates',[EstatesController::class,'getMyEstates']);


### PR DESCRIPTION
This pull request introduces a new API endpoint, /api/estates, that allows for paginated retrieval of a user's estates from the database. The endpoint supports query parameters for page number, results per page, and user ID. The response is formatted in JSON, providing an array of estates with details such as ID, name, coordinates (latitude and longitude), category, price, and currency. Additionally, the response includes metadata such as the current page, last page, and total number of results. 